### PR TITLE
NodeSet API extension

### DIFF
--- a/cmake/CodeCoverage.cmake
+++ b/cmake/CodeCoverage.cmake
@@ -73,7 +73,7 @@ if(EXODUSIICPP_CODE_COVERAGE)
                 ${LLVM_PROFDATA_PATH}
                 merge
                 -sparse
-                ${CMAKE_BINARY_DIR}/test/exodusIIcpp-test-*.profraw
+                ${CMAKE_BINARY_DIR}/test/exodusIIcpp-test.profraw
                 -o ${MERGED_PROFDATA}
         )
 

--- a/include/exodusIIcppNodeSet.h
+++ b/include/exodusIIcppNodeSet.h
@@ -42,6 +42,11 @@ public:
     /// @see get_size
     int get_node_id(std::size_t idx) const;
 
+    /// Get node IDs contained in this node set
+    ///
+    /// @return Node IDs contained in this node set
+    const std::vector<int> & get_node_ids() const;
+
     /// Set node set ID
     ///
     /// @param id Desired ID of the node set

--- a/src/exodusIIcppNodeSet.cpp
+++ b/src/exodusIIcppNodeSet.cpp
@@ -32,6 +32,12 @@ NodeSet::get_node_id(std::size_t idx) const
         throw std::out_of_range("Index of out bounds.");
 }
 
+const std::vector<int> &
+NodeSet::get_node_ids() const
+{
+    return this->node_ids;
+}
+
 void
 NodeSet::set_id(int id)
 {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -36,4 +36,14 @@ mark_as_advanced(FORCE EXODUSIICPP_UNIT_TEST_ASSETS)
 
 configure_file(config.h.in config.h)
 
-gtest_discover_tests(${PROJECT_NAME})
+add_test(
+    NAME ${PROJECT_NAME}
+    COMMAND ${PROJECT_NAME}
+)
+if(EXODUSIICPP_CODE_COVERAGE)
+    set_tests_properties(
+        ${PROJECT_NAME}
+        PROPERTIES
+            ENVIRONMENT LLVM_PROFILE_FILE=${PROJECT_NAME}.profraw
+    )
+endif()

--- a/test/NodeSet_test.cpp
+++ b/test/NodeSet_test.cpp
@@ -3,6 +3,7 @@
 #include <stdexcept>
 
 using namespace exodusIIcpp;
+using namespace testing;
 
 TEST(NodeSetTest, test)
 {
@@ -25,4 +26,6 @@ TEST(NodeSetTest, test)
     EXPECT_THAT(ns.get_node_id(2), 3);
 
     EXPECT_THROW(ns.get_node_id(3), std::out_of_range);
+
+    EXPECT_THAT(ns.get_node_ids(), ElementsAre(1, 2, 3));
 }


### PR DESCRIPTION
- API to get nodes from a NodeSet
- Fixing code coverage generation for llvm-cov
