### PR TITLE
Changing order of searching for exodusII library

### DIFF
--- a/cmake/FindExodusII.cmake
+++ b/cmake/FindExodusII.cmake
@@ -14,7 +14,7 @@ find_path(
 
 find_library(
     EXODUSII_LIBRARY
-        exoIIv2c exodus
+        exodus exoIIv2c
     PATHS
         $ENV{EXODUSII_DIR}/lib
 )


### PR DESCRIPTION
Look for exodus first. This seems to be more robust.
