### PR TITLE
CMake improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,7 @@ jobs:
             libhdf5-dev \
             libexodusii-dev
           echo "CODE_COVERAGE=YES" >> $GITHUB_ENV
+          cat /usr/include/exodusII.h
 
       - name: Install dependencies (macOS)
         if: startsWith(matrix.os, 'macos')

--- a/cmake/exodusIIcppConfig.cmake
+++ b/cmake/exodusIIcppConfig.cmake
@@ -1,5 +1,0 @@
-include(CMakeFindDependencyMacro)
-
-find_dependency(fmt REQUIRED)
-
-include("${CMAKE_CURRENT_LIST_DIR}/exodusIIcppTargets.cmake")

--- a/cmake/exodusIIcppConfig.cmake.in
+++ b/cmake/exodusIIcppConfig.cmake.in
@@ -1,0 +1,17 @@
+set(EXODUSIICPP_VERSION @PROJECT_VERSION@)
+
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/exodusIIcppTargets.cmake")
+
+check_required_components(exodusIIcpp)
+
+find_library(EXODUSIICPP_LIBRARY NAMES exodusIIcpp HINTS ${PACKAGE_PREFIX_DIR}/lib NO_DEFAULT_PATH)
+find_path(EXODUSIICPP_INCLUDE_DIR exodusIIcpp.h HINTS ${PACKAGE_PREFIX_DIR}/include/exodusIIcpp)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+    exodusIIcpp
+    REQUIRED_VARS EXODUSIICPP_LIBRARY EXODUSIICPP_INCLUDE_DIR
+    VERSION_VAR EXODUSIICPP_VERSION
+)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -41,6 +41,12 @@ target_link_libraries(
 
 # Install
 
+configure_package_config_file(
+    ${PROJECT_SOURCE_DIR}/cmake/exodusIIcppConfig.cmake.in
+    exodusIIcppConfig.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/exodusIIcpp
+    NO_SET_AND_CHECK_MACRO
+)
 write_basic_package_version_file(exodusIIcppConfigVersion.cmake
     VERSION ${PROJECT_VERSION}
     COMPATIBILITY AnyNewerVersion
@@ -71,7 +77,7 @@ install(
 
 install(
     FILES
-        "${PROJECT_SOURCE_DIR}/cmake/exodusIIcppConfig.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/exodusIIcppConfig.cmake"
         "${CMAKE_CURRENT_BINARY_DIR}/exodusIIcppConfigVersion.cmake"
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/exodusIIcpp
 )


### PR DESCRIPTION
- cmake: detect netcdf version
- cmake: detect exodusII version
- cmake: require dependency versions
- cmake: do not build gtest if not building with tests
- cmake: improving exodusIIcppConfig.cmake
