### PR TITLE
gha: updating workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,6 @@ jobs:
       matrix:
         include:
           - os: ubuntu-22.04
-          - os: macos-11
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up miniconda
@@ -27,21 +26,17 @@ jobs:
         with:
           python-version: 3.9
           auto-update-conda: false
-          channels: andrsd,conda-forge,defaults
-          channel-priority: strict
-          miniforge-version: latest
-          miniforge-variant: Mambaforge
-          use-mamba: true
+          channels: andrsd,defaults
 
       - name: Checkout source
         uses: actions/checkout@v3
 
       - name: Install dependencies
         run: |
-          mamba install \
+          conda install \
             cmake \
             make \
-            cxx-compiler \
+            mpich-mpicxx \
             exodusii==2022.08.01 \
             fmt==9.1.0 \
             yaml-cpp==0.7.0 \


### PR DESCRIPTION
- dropping macos testing
- no conda-forge
- no mamba
